### PR TITLE
updated to python3 executable

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-teleop-twist-keyboard
 	pkgdesc = ROS - Generic keyboard teleop for twist robots.
 	pkgver = 0.6.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/teleop_twist_keyboard
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/teleop_twist_keyboard'
 pkgname='ros-melodic-teleop-twist-keyboard'
 pkgver='0.6.2'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(ros-melodic-catkin)
@@ -17,13 +17,6 @@ ros_depends=(ros-melodic-geometry-msgs
   ros-melodic-rospy)
 depends=(${ros_depends[@]})
 
-# Git version (e.g. for debugging)
-# _tag=release/melodic/teleop_twist_keyboard/${pkgver}-${_pkgver_patch}
-# _dir=${pkgname}
-# source=("${_dir}"::"git+https://github.com/ros-gbp/teleop_twist_keyboard-release.git"#tag=${_tag})
-# sha256sums=('SKIP')
-
-# Tarball version (faster download)
 _dir="teleop_twist_keyboard-${pkgver}"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-teleop/teleop_twist_keyboard/archive/${pkgver}.tar.gz")
 sha256sums=('7c0c2c0ef2f47e52922beeac94c093b54677318397b4415ac78933aca5079b0c')
@@ -45,7 +38,7 @@ build() {
         -DCMAKE_BUILD_TYPE=Release \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \
-        -DPYTHON_EXECUTABLE=/usr/bin/python2 \
+        -DPYTHON_EXECUTABLE=/usr/bin/python \
         -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
         -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so \
         -DPYTHON_BASENAME=-python2.7 \


### PR DESCRIPTION
Resolves build error

Note: package doesnt use the other variables which is why package still builds even when some variables are set to 2.7 instead of 3.8